### PR TITLE
Use a more recent StartSSL guide instead

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@ $> openssl speed ecdh</pre>
       <p>Ensure you have a shared session cache to get good cache hit rate on resumed sessions across different servers. Also, ensure you expire and rotate your sessions and session ticket keys in a secure manner - <a href="https://www.imperialviolet.org/2013/06/27/botchingpfs.html">especially when forward secrecy is enabled</a>.</p>
 
       <h4>What about certificate costs?</h4>
-      <p>You can <a href="https://github.com/ioerror/duraconf/blob/master/startssl/README.markdown">get a free  certificate from StartSSL</a>. If you need wildcard support, or EV verification, then you will have to pay a bit extra &mdash; the security and integrity of your visitors data is well worth it.</p>
+      <p>You can <a href="https://konklone.com/post/switch-to-https-now-for-free">get a free  certificate from StartSSL</a>. If you need wildcard support, or EV verification, then you will have to pay a bit extra &mdash; the security and integrity of your visitors data is well worth it.</p>
 
       <h4>How does this site measure up?</h4>
       <p>It's running on latest build of nginx (1.5.10) with resumption, OCSP stapling, 1400 byte TLS records, forward secrecy, NPN + SPDY/3.1. In other words, it's nearly as good as it gets - <a href="https://github.com/igrigorik/istlsfastyet.com/blob/master/nginx.conf">see config</a>.</p>


### PR DESCRIPTION
This replaces the link to the [duraconf StartSSL guide](https://github.com/ioerror/duraconf/blob/master/startssl/README.markdown) with a link to [my StartSSL guide](https://konklone.com/post/switch-to-https-now-for-free). 

A self-serving pull request! But the duraconf guide hasn't been updated in 3 years, mine was made in September and I update it whenever I find relevant things. I think it's pretty good, and it's been well-used and gets steady traffic.
