### PR TITLE
Use HTTPS for more links.

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ $> openssl speed ecdh</pre>
         <li><a href="http://chimera.labs.oreilly.com/books/1230000000545/ch04.html#_http_strict_transport_security_hsts">HTTP Strict Transport Security (HSTS)</a></li>
       </ul>
 
-      <p>To deliver the best performance, run down the <a href="http://chimera.labs.oreilly.com/books/1230000000545/ch04.html#_performance_checklist_2">TLS performance checklist</a> and use a tool like <a href="http://hpbn.co/qualys">Qualys SSL Server Test</a> to scan your server for common configuration and security flaws.</p>
+      <p>To deliver the best performance, run down the <a href="http://chimera.labs.oreilly.com/books/1230000000545/ch04.html#_performance_checklist_2">TLS performance checklist</a> and use a tool like <a href="https://www.ssllabs.com/ssltest/">Qualys SSL Server Test</a> to scan your server for common configuration and security flaws.</p>
     </div>
 
     <div class="small-12 medium-4 large-4 columns panel">
@@ -149,18 +149,18 @@ $> openssl speed ecdh</pre>
         </thead>
         <tbody>
           <tr>
-            <td><a href="http://httpd.apache.org/docs/2.4/mod/mod_ssl.html">Apache</a></td>
-            <td class="ok"><a href="http://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslsessioncache">yes</a></td>
-            <td class="ok"><a href="http://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslsessionticketkeyfile">yes</a></td>
-            <td class="ok"><a href="http://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslusestapling">yes</a></td>
+            <td><a href="https://httpd.apache.org/docs/2.4/mod/mod_ssl.html">Apache</a></td>
+            <td class="ok"><a href="https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslsessioncache">yes</a></td>
+            <td class="ok"><a href="https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslsessionticketkeyfile">yes</a></td>
+            <td class="ok"><a href="https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslusestapling">yes</a></td>
             <td class="alert">no</td>
             <td class="alert"><a href="https://issues.apache.org/bugzilla/show_bug.cgi?id=56028">no*</a></td>
             <td class="ok"><a href="https://wiki.mozilla.org/Security/Server_Side_TLS#Apache">yes</a></td>
             <td class="warn"><a href="https://code.google.com/p/mod-spdy/">mod_spdy</a></td>
           </tr>
           <tr>
-            <td><a href="http://trafficserver.readthedocs.org/en/latest/reference/configuration/">ATS</a></td>
-            <td class="ok"><a href="http://trafficserver.readthedocs.org/en/latest/reference/configuration/records.config.en.html#proxy-config-ssl-session-cache-timeout">yes</a></td>
+            <td><a href="https://trafficserver.readthedocs.org/en/latest/reference/configuration/">ATS</a></td>
+            <td class="ok"><a href="https://trafficserver.readthedocs.org/en/latest/reference/configuration/records.config.en.html#proxy-config-ssl-session-cache-timeout">yes</a></td>
             <td class="ok"><a href="https://cwiki.apache.org/confluence/display/TS/What's+new+in+v4.2.x#What'snewinv4.2.x-RFC5077TLSSessiontickets">yes</a></td>
             <td class="alert">no</td>
             <td class="warn"><a href="https://cwiki.apache.org/confluence/display/TS/What's+new+in+v4.2.x#What'snewinv4.2.x-ConfiguremaxTLSrecordsize">static</a></td>
@@ -263,7 +263,7 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
             <td class="alert">no</td>
             <td class="alert">no</td>
-            <td class="ok"><a href="http://aws.amazon.com/about-aws/whats-new/2014/02/19/elastic-load-balancing-perfect-forward-secrecy-and-more-new-security-features/">yes</a></td>
+            <td class="ok"><a href="https://aws.amazon.com/about-aws/whats-new/2014/02/19/elastic-load-balancing-perfect-forward-secrecy-and-more-new-security-features/">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>
@@ -343,10 +343,10 @@ $> openssl speed ecdh</pre>
       <p>Quality of implementation matters &mdash; no argument there &mdash; and you should do your due dilligence. That said, you need to <i>test on your own hardware and with realistic traffic patterns</i> to get an accurate picture of what works best for your specific workload. Don't trust outdated benchmarks, update your OpenSSL libraries, update your server, and run the tests.</p>
 
       <h4>TLS operational costs are still higher, right?</h4>
-      <p>Not necessarily. Once you enable and optimize your TLS stack you're also well on your way to deploying SPDY and HTTP/2. Unlike HTTP/1.1, both of these protocols require only a single connection to the server, which means fewer sockets, memory buffers, TLS handshakes, and so on. As a result, it may well be the case that you will be able to <a href="http://www.neotys.com/blog/performance-of-spdy-enabled-web-servers/">handle more users with fewer resources</a>.</p>
+      <p>Not necessarily. Once you enable and optimize your TLS stack you're also well on your way to deploying SPDY and HTTP/2. Unlike HTTP/1.1, both of these protocols require only a single connection to the server, which means fewer sockets, memory buffers, TLS handshakes, and so on. As a result, it may well be the case that you will be able to <a href="https://www.neotys.com/blog/performance-of-spdy-enabled-web-servers/">handle more users with fewer resources</a>.</p>
 
       <h4>TLS still adds an extra RTT; can we fix that?</h4>
-      <p>One possible route is to leverage TCP Fast Open, which would allow us to send the ClientHello within the TCP SYN packet &mdash; that would cut another RTT. In the meantime, both <a href="http://www.ietf.org/proceedings/88/slides/slides-88-tls-4.pdf">TLS 1.3</a> and QUIC are experimenting with "zero-RTT" handshake mechanisms. See <a href="https://docs.google.com/document/d/1g5nIXAIkN_Y-7XJW5K45IblHd_L2f5LTaDUDwvZ5L6g/edit">QUIC crypto doc</a> and <a href="http://www.youtube.com/watch?v=hQZ-0mXFmk8">this GDL episode</a> for a general introduction to QUIC.</p>
+      <p>One possible route is to leverage TCP Fast Open, which would allow us to send the ClientHello within the TCP SYN packet &mdash; that would cut another RTT. In the meantime, both <a href="https://www.ietf.org/proceedings/88/slides/slides-88-tls-4.pdf">TLS 1.3</a> and QUIC are experimenting with "zero-RTT" handshake mechanisms. See <a href="https://docs.google.com/document/d/1g5nIXAIkN_Y-7XJW5K45IblHd_L2f5LTaDUDwvZ5L6g/edit">QUIC crypto doc</a> and <a href="https://www.youtube.com/watch?v=hQZ-0mXFmk8">this GDL episode</a> for a general introduction to QUIC.</p>
 
       <h4>Which ciphersuite should I be using?</h4>
       <p>Mozilla maintains a great wiki page <a href="https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_Ciphersuite">with a recommended ciphersuite list</a> and server configuration tips.</p>


### PR DESCRIPTION
- IETF
- YouTube
- Apache
- Qualys
- ReadTheDocs (though the first link is broken)
- AWS
