### PR TITLE
Update nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,9 @@
   server {
     listen 173.230.151.99:443 ssl spdy;
     server_name istlsfastyet.com www.istlsfastyet.com;
+    
+    # For non SPDY clients a long keepalive make SSL site faster
+    keepalive_timeout 300;
 
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     


### PR DESCRIPTION
For non SPDY clients tuning the keepalive timeout allows for faster browsing on ssl sites. Might not make sense for a page like istlsfastyet.com since it's very static, it's unlikely that users do any further interaction with the site, but will help in other scenarios.
