### PR TITLE
AWS ELB & CloudFront run different SSL/TLS stacks, so keep them separate

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,13 +257,23 @@ $> openssl speed ecdh</pre>
             <td class="ok">spdy/3.1</td>
           </tr>
           <tr>
-            <td>AWS ELB &amp; CloudFront</td>
+            <td>AWS ELB</td>
+            <td class="ok">yes</td>
+            <td class="ok">yes</td>
+            <td class="alert">no</td>
+            <td class="alert">no</td>
+            <td class="alert">no</td>
+            <td class="ok"><a href="https://aws.amazon.com/about-aws/whats-new/2014/02/19/elastic-load-balancing-perfect-forward-secrecy-and-more-new-security-features/">yes</a></td>
+            <td class="alert">no</td>
+          </tr>
+          <tr>
+            <td>AWS CloudFront</td>
+            <td class="alert">no</td>
             <td class="ok">yes</td>
             <td class="alert">no</td>
             <td class="alert">no</td>
             <td class="alert">no</td>
             <td class="alert">no</td>
-            <td class="ok"><a href="https://aws.amazon.com/about-aws/whats-new/2014/02/19/elastic-load-balancing-perfect-forward-secrecy-and-more-new-security-features/">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
- ELBs support session IDs, session tickets, and PFS
- CloudFront supports session tickets only

Closes #21
