### PR TITLE
Consolidate http server blocks

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,16 +4,10 @@
 
    server {
     listen 173.230.151.99:80;
-    server_name www.istlsfastyet.com;
+    server_name istlsfastyet.com www.istlsfastyet.com;
 
-    # redirect to naked domain to avoid http://www -> https://www -> https:// chain.
+    # redirect to naked domain avoiding http://www -> https://www -> https:// chain.
     rewrite ^ https://istlsfastyet.com$request_uri? permanent;
-  }
-
-  server {
-    listen 173.230.151.99:80;
-    server_name istlsfastyet.com;
-    rewrite ^ https://$http_host$request_uri? permanent;
   }
 
   ssl_session_cache shared:SSL:10m;  # 10MB -> ~40,000 sessions.
@@ -23,13 +17,13 @@
   server {
     listen 173.230.151.99:443 ssl spdy;
     server_name istlsfastyet.com www.istlsfastyet.com;
-    
+
     # Adjust connection keepalive for SPDY and non-SPDY clients:
     spdy_keepalive_timeout 300; # up from 180 secs default
     keepalive_timeout 300; # up from 75 secs default
 
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    
+
     # courtesy of https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_Ciphersuite
     ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK;
     ssl_prefer_server_ciphers on;
@@ -43,7 +37,7 @@
     ssl_stapling_verify on;
     ssl_trusted_certificate /home/istlsfastyet/tls/ca.crt;
     resolver 8.8.8.8;
-    
+
     # nginx does not auto-rotate session ticket keys: only a HUP / restart will do so and
     # when a restart is performed the previous key is lost, which resets all previous
     # sessions. The fix for this is to setup a manual rotation mechanism:


### PR DESCRIPTION
It's not necessary to have two blocks for listening to `http://www.is..` and `http://is..` to both redirect to `https://is..`
