### PR TITLE
Use simpler location blocks

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -67,7 +67,7 @@
       access_log off;
     }
 
-    location ~* \index.html$ {
+    location  /index.html$ {
       expires 60m;
     }
   }


### PR DESCRIPTION
there's no need for a regex match for the url `/index.html`

Use prefix-matching for assets as that's the nginx-way® and the rule is simpler.

Note that this isn't the case on istlsfastyet.com:

> make sure you are using cache busting filenames or query params
