### PR TITLE
Added Citrix NetScaler ADC to Servers Table

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,6 +208,16 @@ $> openssl speed ecdh</pre>
             <td class="ok">yes</td>
             <td class="alert">no</td>
           </tr>
+		  <tr>
+            <td><a href="https://www.citrix.com/products/netscaler-application-delivery-controller/overview.html?posit=glnav">Citrix NetScaler</a></td>
+            <td class="ok">yes</td>
+            <td class="ok">yes</td>
+            <td class="alert"><a href="http://discussions.citrix.com/topic/354716-ocsp-stapling/">no</a></td>
+            <td class="alert">no</td>
+            <td class="ok">yes</td>
+            <td class="ok">yes</td>
+            <td class="warn">spdy/3.0</td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
Only bit I am not certain on is the TLS Record Size bit, however after checking through the documentation here: http://support.citrix.com/proddocs/topic/netscaler/ns-gen-netscaler10-5-wrapper-con.html

I couldn't find any additional info.

Paul
