### PR TITLE
updated netscaler to show it doesn't support SSL Tickets

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@ $> openssl speed ecdh</pre>
 		  <tr>
             <td><a href="https://www.citrix.com/products/netscaler-application-delivery-controller/overview.html?posit=glnav">Citrix NetScaler</a></td>
             <td class="ok">yes</td>
-            <td class="ok">yes</td>
+            <td class="alert">no</td>
             <td class="alert"><a href="http://discussions.citrix.com/topic/354716-ocsp-stapling/">no</a></td>
             <td class="alert">no</td>
             <td class="ok">yes</td>


### PR DESCRIPTION
http://support.citrix.com/proddocs/topic/netscaler-traffic-management-10-map/ns-ssl-config-session-reuse-tsk.html

Default is ON using Session-IDs
