### PR TITLE
Added IPv6 support to resolve HTTP 502 on IPv6 networks

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -4,6 +4,7 @@
 
   server {
     listen 173.230.151.99:80;
+    listen [2600:3c01::f03c:91ff:fedf:810c]:80;
     server_name istlsfastyet.com www.istlsfastyet.com;
 
     # redirect to naked domain avoiding http://www -> https://www -> https:// chain.
@@ -16,6 +17,7 @@
 
   server {
     listen 173.230.151.99:443 ssl spdy;
+    listen [2600:3c01::f03c:91ff:fedf:810c]:443 ssl spdy;
     server_name www.istlsfastyet.com;
 
     rewrite ^ https://istlsfastyet.com$request_uri? permanent;
@@ -25,6 +27,7 @@
 
   server {
     listen 173.230.151.99:443 ssl spdy;
+    listen [2600:3c01::f03c:91ff:fedf:810c]:443 ssl spdy;
     server_name istlsfastyet.com;
 
     # Path for static files


### PR DESCRIPTION
Both of our websites weren't working in Chrome on Nexus 5 Lollipop via T-Mobile LTE in Denver (test-ipv6.com from phone). Error: "Error 502 Bad - Request. The server could not resolve your request for url Http://isitfastyet.com".  This ApacheBench also fails from an IPv6 network:
```
[~]$ ab http://istlsfastyet.com/
This is ApacheBench, Version 2.3 <$Revision: 1528965 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking istlsfastyet.com (be patient)...apr_socket_recv: Connection refused (111)
```

**Ensure nginx is serving up IPv6**
```
[~]$ sudo netstat -nlp | grep nginx
tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      23034/nginx.conf
tcp        0      0 0.0.0.0:443             0.0.0.0:*               LISTEN      23034/nginx.conf
tcp6       0      0 :::80                   :::*                    LISTEN      23034/nginx.conf
tcp6       0      0 :::443                  :::*                    LISTEN      23034/nginx.conf
```

**I applied [this fix](http://stackoverflow.com/questions/15802057/apache-bench-connection-refused-61-apr-socket-recv/27309451#27309451) to my `nginx.conf` and it should work for yours.**

```
$ nslookup -query=AAAA istlsfastyet.com
Server:		8.8.8.8
Address:	8.8.8.8#53

Non-authoritative answer:
istlsfastyet.com	has AAAA address 2600:3c01::f03c:91ff:fedf:810c
```