### PR TITLE
Instart Logic: Fix the NPN field instead of OCSP stapling

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,9 +320,9 @@ $> openssl speed ecdh</pre>
             <td>Instart Logic</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="ok">yes</td>
-            <td class="warn">configurable (static)</td>
             <td class="alert">no</td>
+            <td class="warn">configurable (static)</td>
+            <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="ok">spdy/3.1</td>
           </tr>


### PR DESCRIPTION
Albeit we do support OCSP Stapling, we have not yet enabled it so will enable that box once we are comfortable
Meanwhile we do support NPN/ALPN and hence that check
