### PR TITLE
Adding Hitch (scalable TLS proxy by Varnish Software)

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,16 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
           </tr>
           <tr>
+            <td><a href="https://github.com/varnish/hitch">Hitch</a></td>
+            <td class="ok">yes</td>
+            <td class="ok">yes</td>
+            <td class="warn"><a href="https://github.com/varnish/hitch/issues/19">planned</a></td>
+            <td class="alert">no</td>
+            <td class="warn">planned</td>
+            <td class="ok">yes</td>
+            <td class="warn">HTTP/2 planned</td>
+          </tr>
+          <tr>
             <td><a href="http://www.iis.net/configreference">IIS</a></td>
             <td class="ok">yes</td>
             <td class="ok"><a href="http://technet.microsoft.com/en-us/library/hh831771.aspx">yes</a></td>


### PR DESCRIPTION
Hitch is brought to you by Varnish Software <https://github.com/varnish/hitch>

Hitch is a libev-based high performance SSL/TLS proxy, usually deployed for terminating HTTPS traffic in front of other origin servers.

Notable features:
 * TLS1.0, TLS1.1 and TLS1.2 support
 * SNI, with and without wildcard certificates.
 * Support for HAproxy's PROXY protocol.

Hitch is open-source software, licensed under the 2-clause BSD license. It is maintained by Dag Haavi Finstad / Varnish Software.