### PR TITLE
Add s2n from Amazon

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,16 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
             <td class="ok"><a href="https://github.com/indutny/node-spdy">spdy/3.1</a>, <a href="https://github.com/molnarg/node-http2">http/2</a></td>
           </tr>
+          <tr>
+            <td><a href="https://github.com/awslabs/s2n">s2n</a></td>
+            <td class="ok">yes</td>
+            <td class="alert"><a href="https://github.com/awslabs/s2n/issues/4">no</a></td>
+            <td class="ok"><a href="https://github.com/awslabs/s2n/issues/18">yes</a></td>
+            <td class="alert"><a href="https://github.com/awslabs/s2n/issues/2">no</a></td>
+            <td class="ok"><a href="https://github.com/awslabs/s2n/issues/8">yes</a></td>
+            <td class="ok">yes</td>
+            <td class="alert">no</td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
https://blogs.aws.amazon.com/security/post/TxCKZM94ST1S6Y/Introducing-s2n-a-New-Open-Source-TLS-Implementation

Not sure if this is appropriate for this table, especially since you don't list OpenSSL, LibreSSL, PolarSSL, GnuTLS, etc. If not, that's fine, but figured I'd mention it.

Also, did my best to ensure the information is correct, but could always use a second pair of eyes.