### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="http://httpd.apache.org/docs/trunk/mod/mod_h2.html">yes</a></td>
           </tr>
           <tr>
-            <td><a href="https://trafficserver.readthedocs.org/en/latest/reference/configuration/index.en.html">ATS</a></td>
+            <td><a href="https://docs.trafficserver.apache.org/en/latest/index.html">ATS</a></td>
             <td class="ok"><a href="https://trafficserver.readthedocs.org/en/latest/reference/configuration/records.config.en.html#proxy-config-ssl-session-cache-timeout">yes</a></td>
             <td class="ok"><a href="https://cwiki.apache.org/confluence/display/TS/What's+new+in+v4.2.x#What'snewinv4.2.x-RFC5077TLSSessiontickets">yes</a></td>
             <td class="ok"><a href="https://issues.apache.org/jira/browse/TS-2367">yes</a></td>

--- a/index.html
+++ b/index.html
@@ -160,13 +160,13 @@ $> openssl speed ecdh</pre>
           </tr>
           <tr>
             <td><a href="https://docs.trafficserver.apache.org/en/latest/index.html">ATS</a></td>
-            <td class="ok"><a href="https://trafficserver.readthedocs.org/en/latest/reference/configuration/records.config.en.html#proxy-config-ssl-session-cache-timeout">yes</a></td>
+            <td class="ok"><a href="https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.config.en.html#proxy-config-ssl-session-cache-timeout">yes</a></td>
             <td class="ok"><a href="https://cwiki.apache.org/confluence/display/TS/What's+new+in+v4.2.x#What'snewinv4.2.x-RFC5077TLSSessiontickets">yes</a></td>
             <td class="ok"><a href="https://issues.apache.org/jira/browse/TS-2367">yes</a></td>
             <td class="ok"><a href="https://issues.apache.org/jira/browse/TS-2503">dynamic</a></td>
             <td class="ok"><a href="http://mail-archives.us.apache.org/mod_mbox/www-announce/201206.mbox/%3C4FE245C6.6060900@apache.org%3E">yes</a></td>
             <td class="ok"><a href="https://issues.apache.org/jira/browse/TS-2372">yes</a></td>
-            <td class="ok"><a href="https://docs.trafficserver.apache.org/en/latest/reference/configuration/records.config.en.html#http-2-configuration">yes</a></td>
+            <td class="ok"><a href="https://docs.trafficserver.apache.org/en/latest/admin-guide/files/records.config.en.html#http-2-configuration">yes</a></td>
           </tr>
          <tr>
             <td><a href="https://github.com/indutny/bud">bud</a></td>


### PR DESCRIPTION
The documentation for Apache Traffic Server project is no longer provided by `readthedocs` project. It has instead been moved to the project's own subdomain.