### PR TITLE
add H2O (h2o.examp1e.net)

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,16 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config">yes</a></td>
             <td class="ok"><a href="https://godoc.org/golang.org/x/net/http2">yes</a></td>
           </tr>
+          <tr>
+            <td><a href="https://h2o.examp1e.net/">H2O</a></td>
+            <td class="ok"><a href="https://h2o.examp1e.net/configure/base_directives.html#ssl-session-resumption">yes</a></td>
+            <td class="ok"><a href="https://h2o.examp1e.net/configure/base_directives.html#ssl-session-resumption">yes</a></td>
+            <td class="ok"><a href="https://h2o.examp1e.net/configure/base_directives.html#ocsp-update-interval">yes</a></td>
+            <td class="warn">static</td>
+            <td class="ok">yes</td>
+            <td class="ok"><a href="https://h2o.examp1e.net/configure/base_directives.html#ssl-session-resumption-ticket-based">yes</a></td>
+            <td class="ok"><a href="https://h2o.examp1e.net/configure/http2_directives.html">yes</a></td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
Hello,

This PR adds H2O to the list of servers.

I have set `Dynamic record sizing` column is set to `static`, regarding the fact that H2O hard-codes the TLS record size to be slightly among 1,400 bytes (see https://github.com/h2o/h2o/blob/v1.7.0/lib/common/socket.c#L375-L377).

Please let me know if you have any suggestions.  Thank you in advance.