### PR TITLE
Updated Forward Secrecy state for MaxCDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://www.maxcdn.com/blog/now-shipping-ocsp-stapling/">yes</a></td>
             <td class="alert">no</td>
             <td class="ok">yes</td>
-            <td class="alert">no</td>
+            <td class="ok">yes</td>
             <td class="ok">spdy/3.1</td>
           </tr>
           <tr>


### PR DESCRIPTION
Hello Mr. Grigorik,

We have (finally) enabled Forward Secrecy on our edge servers. :confetti_ball: 

Proof: https://www.ssllabs.com/ssltest/analyze.html?d=code.jquery.com&hideResults=on

Other sites are in the process of being moved over to the new TLS config.

Next: Dynamic record sizing, then HTTP/2.