### PR TITLE
Add supported TLS and HTTP/2 features for Brocade virtual Traffic Manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,14 +179,14 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
           </tr>
           <tr>
-            <td><a href="http://www.brocade.com/en/products-services/application-delivery-controllers/virtual-traffic-manager.html">Brocade vTM</a></td>
-            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
+            <td><a href="https://www.brocade.com/en/products-services/application-delivery-controllers/virtual-traffic-manager.html">Brocade vTM</a></td>
+            <td class="ok"><a href="https://www.brocade.com/content/dam/common/documents/content-types/user-guide/brocade-vtm-10.3-userguide.pdf#page=229">yes</a></td>
             <td class="alert">no</td>
-            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
+            <td class="ok"><a href="https://www.brocade.com/content/dam/common/documents/content-types/user-guide/brocade-vtm-10.3-userguide.pdf#page=230">yes</a></td>
             <td class="alert">no</td>
-            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
-            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
-            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
+            <td class="ok"><a href="https://www.brocade.com/content/dam/common/documents/content-types/user-guide/brocade-vtm-10.3-userguide.pdf#page=180">yes</a></td>
+            <td class="ok"><a href="https://www.brocade.com/content/dam/common/documents/content-types/user-guide/brocade-vtm-10.3-userguide.pdf#page=224">yes</a></td>
+            <td class="ok"><a href="https://www.brocade.com/content/dam/common/documents/content-types/user-guide/brocade-vtm-10.3-userguide.pdf#page=180">yes</a></td>
           </tr>
           <tr>
             <td><a href="https://support.f5.com/kb/en-us/solutions/public/14000/700/sol14783.html">F5 BIG-IP</a></td>

--- a/index.html
+++ b/index.html
@@ -179,6 +179,16 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
           </tr>
           <tr>
+            <td><a href="http://www.brocade.com/en/products-services/application-delivery-controllers/virtual-traffic-manager.html">Brocade vTM</a></td>
+            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
+            <td class="alert">no</td>
+            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
+            <td class="alert">no</td>
+            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
+            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
+            <td class="ok"><a href="http://www.brocade.com/en/backend-content/pdf-page.html?/content/dam/common/documents/content-types/datasheet/brocade-virtual-traffic-manager-ds.pdf">yes</a></td>
+          </tr>
+          <tr>
             <td><a href="https://support.f5.com/kb/en-us/solutions/public/14000/700/sol14783.html">F5 BIG-IP</a></td>
             <td class="ok"><a href="https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-ssl-administration-11-6-0/5.html#unique_828493537">yes</a></td>
             <td class="ok"><a href="https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-ssl-administration-11-6-0/5.html#unique_774070786">yes</a></td>


### PR DESCRIPTION
Hi Ilya,

I've added supported TLS and HTTP/2 features for Brocade virtual Traffic Manager to your table (disclaimer: I work on this product). Thanks for a great website + book.

Regards,
Jonathan.