### PR TITLE
Akamai is not currently supporting OCSP stapling

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@ $> openssl speed ecdh</pre>
             <td>Akamai</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="ok">yes</td>
+            <td class="alert">no</td>
             <td class="warn">configurable (static)</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>


### PR DESCRIPTION
Learned today from CCare @ Akamai. Advised it will be "enabled again in the future", but they have no ETA to share. :disappointed: