### PR TITLE
Adjust Fastly dynamic record sizing nomenclature

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@ $> openssl speed ecdh</pre>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="ok">yes</td>
+            <td class="ok">dynamic</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="alert">no</td>


### PR DESCRIPTION
Adjusting Faslty's entry for dynamic record sizing from "yes" to "dynamic" to match other providers in that column.  Sorry for not catching this in the initial request.