### PR TITLE
Golang 1.7 supports dynamic record sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,10 +273,10 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#ClientSessionState">yes</a></td>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config.SetSessionTicketKeys">yes</a></td>
             <td class="warn"><a href="https://golang.org/pkg/crypto/tls/#Certificate">optional</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://golang.org/doc/go1.7#crypto/tls">yes</a></td>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config">yes</a></td>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config">yes</a></td>
-            <td class="ok"><a href="https://godoc.org/golang.org/x/net/http2">yes</a></td>
+            <td class="ok"><a href="https://golang.org/doc/go1.6#http2">yes</a></td>
           </tr>
           <tr>
             <td><a href="https://nghttp2.org/documentation/nghttpx.1.html">nghttpx</a></td>


### PR DESCRIPTION
Also update HTTP/2 link to point to the Go 1.6 release notes

Note that the link for dynamic record sizing points to the Go 1.7 release notes, which haven't been published yet, as Go 1.7 only just got its beta1. In the mean time, the draft release notes can be found at https://tip.golang.org/doc/go1.7#crypto/tls

I'd advise waiting for Go 1.7 to be released in a couple months before merging this PR. Thought I'd prepare it anyway, as soon as I saw the good news in the release notes.

BTW, didn't know whether to put a “yes” or “dynamic” in there.