### PR TITLE
Set HTTP/2 to yes for Fastly

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@ $> openssl speed ecdh</pre>
             <td class="ok">dynamic</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="ok">yes</td>
+            <td class="ok"><a href="https://www.fastly.com/blog/announcing-limited-availability-http2">yes</a></td>
           </tr>
           <tr>
             <td>Google App Engine</td>

--- a/index.html
+++ b/index.html
@@ -394,7 +394,7 @@ $> openssl speed ecdh</pre>
             <td class="ok">dynamic</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="alert">no</td>
+            <td class="ok">yes</td>
           </tr>
           <tr>
             <td>Google App Engine</td>


### PR DESCRIPTION
Another quick update - we now support HTTP/2

https://www.fastly.com/blog/announcing-limited-availability-http2