### PR TITLE
Updated AWS ELB to Support HTTP/2

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
             <td class="alert">no</td>
             <td class="ok"><a href="https://aws.amazon.com/about-aws/whats-new/2014/02/19/elastic-load-balancing-perfect-forward-secrecy-and-more-new-security-features/">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://aws.amazon.com/de/blogs/aws/new-aws-application-load-balancer/">yes</a></td>
           </tr>
           <tr>
             <td>AWS CloudFront</td>


### PR DESCRIPTION
AWS recently announced the general availability of their new ELB type "Application Load Balancer", supporting HTTP/2. Source: https://aws.amazon.com/de/blogs/aws/new-aws-application-load-balancer/