### PR TITLE
CloudFront supports HTTP/2 now

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="ok">yes</td>
+            <td class="ok"><a href="https://aws.amazon.com/about-aws/whats-new/2016/09/amazon-cloudfront-now-supports-http2/">yes</a></td>
           </tr>
           <tr>
             <td>CDN77</td>

--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="alert">no</td>
+            <td class="ok">yes</td>
           </tr>
           <tr>
             <td>CDN77</td>


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2016/09/amazon-cloudfront-now-supports-http2/