### PR TITLE
Added AWS Application Load Balancer section

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://http2.akamai.com/">yes</a></td>
           </tr>
           <tr>
-            <td>AWS ELB</td>
+            <td>AWS ELB (Classic)</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="alert">no</td>
@@ -344,6 +344,16 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
             <td class="ok"><a href="https://aws.amazon.com/about-aws/whats-new/2014/02/19/elastic-load-balancing-perfect-forward-secrecy-and-more-new-security-features/">yes</a></td>
             <td class="alert">no</td>
+          </tr>
+          <tr>
+            <td>AWS ELB (Application)</td>
+            <td class="ok">yes</td>
+            <td class="ok">yes</td>
+            <td class="alert">no</td>
+            <td class="alert">no</td>
+            <td class="ok">yes</td>
+            <td class="ok"><a href="https://aws.amazon.com/about-aws/whats-new/2014/02/19/elastic-load-balancing-perfect-forward-secrecy-and-more-new-security-features/">yes</a></td>
+            <td class="ok"><a href="https://aws.amazon.com/blogs/aws/new-aws-application-load-balancer/">yes</a></td>
           </tr>
           <tr>
             <td>AWS CloudFront</td>


### PR DESCRIPTION
Updates the CDN section of the page to add an AWS Application Load Balancer section and differentiate between the classic and application versions.

Also updates the section to include new updates made to the Application Load Balancer such as HTTP/2.