### PR TITLE
Hitch w/ ALPN/NPN and HTTP/2 plaintext support

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,9 +223,9 @@ $> openssl speed ecdh</pre>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://github.com/varnish/hitch/blob/master/docs/configuration.md#ocsp-stapling">yes</a></td>
             <td class="alert">no</td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://github.com/varnish/hitch/blob/master/docs/configuration.md#alpnnpn-support">yes</a></td>
             <td class="ok">yes</td>
-            <td class="alert">no</td>
+            <td class=warn><a href="https://github.com/varnish/hitch/blob/master/CHANGES.rst#hitch-140-beta1-2016-08-26">via an h2c PROXY</a></td>
           </tr>
           <tr>
             <td><a href="http://www.iis.net/configreference">IIS</a></td>


### PR DESCRIPTION
Hitch requires an h2c server such as Varnish 5.0 to handle the ALPN hint it provides and thus support H2 towards the client.