### PR TITLE
Add Netlify to the list of PaaS

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,6 +466,16 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://www.instartlogic.com/blog/upgrading-http2">yes</a></td>
           </tr>
           <tr>
+            <td>KeyCDN</td>
+            <td class="ok">yes</td>
+            <td class="ok">yes</td>
+            <td class="ok"><a href="https://www.keycdn.com/support/ocsp-stapling/">yes</a></td>
+            <td class="warn">configurable (static)</td>
+            <td class="ok">yes</td>
+            <td class="ok">yes</td>
+            <td class="ok"><a href="https://www.keycdn.com/blog/keycdn-http2-support/">yes</a></td>
+          </tr>
+          <tr>
             <td>Limelight</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
@@ -486,14 +496,14 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://www.maxcdn.com/blog/http2-support/">yes</a></td>
           </tr>
           <tr>
-            <td>KeyCDN</td>
+            <td>Netlify</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="ok"><a href="https://www.keycdn.com/support/ocsp-stapling/">yes</a></td>
-            <td class="warn">configurable (static)</td>
+            <td class="ok">yes</td>
+            <td class="ok">dynamic</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="ok"><a href="https://www.keycdn.com/blog/keycdn-http2-support/">yes</a></td>
+            <td class="ok"><a href="https://www.netlify.com/blog/2015/10/20/netlify-news-no.-6/">yes</a></td>
           </tr>
           <tr>
             <td>QUANTIL</td>


### PR DESCRIPTION
Netlify uses ATS in the CDN pops, we provide all guarantees ATS provides out of the box.

I reorganized the list of PaaS to be alphabetically sorted too.