### PR TITLE
Fix link to Go 1.7 release notes wrt dynamic record sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#ClientSessionState">yes</a></td>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config.SetSessionTicketKeys">yes</a></td>
             <td class="warn"><a href="https://golang.org/pkg/crypto/tls/#Certificate">optional</a></td>
-            <td class="ok"><a href="https://golang.org/doc/go1.7#crypto/tls">yes</a></td>
+            <td class="ok"><a href="https://golang.org/doc/go1.7#crypto_tls">yes</a></td>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config">yes</a></td>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config">yes</a></td>
             <td class="ok"><a href="https://golang.org/doc/go1.6#http2">yes</a></td>


### PR DESCRIPTION
Anchor was changed from crypto/tls to crypto_tls in golang/go@55559f1