### PR TITLE
set TLS record sizing to H2O to `dynamic`

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://h2o.examp1e.net/configure/base_directives.html#ssl-session-resumption">yes</a></td>
             <td class="ok"><a href="https://h2o.examp1e.net/configure/base_directives.html#ssl-session-resumption">yes</a></td>
             <td class="ok"><a href="https://h2o.examp1e.net/configure/base_directives.html#ocsp-update-interval">yes</a></td>
-            <td class="warn"><a href="https://github.com/h2o/h2o/blob/v1.7.0/lib/common/socket.c#L375-L377">static</a> (1.4k)</td>
+            <td class="warn"><a href="https://h2o.examp1e.net/configure/http2_directives.html#latency-optimization">dynamic</a></td>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://h2o.examp1e.net/configure/base_directives.html#ssl-session-resumption-ticket-based">yes</a></td>
             <td class="ok"><a href="https://h2o.examp1e.net/configure/http2_directives.html">yes</a></td>


### PR DESCRIPTION
You may also want to set it to `feedback-based` or something to reflect the fact that H2O uses feedback from TCP/IP stack (CWND and latency) to decide the strategy.