### PR TITLE
h2o: add support for 0-RTT TLS1.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,8 +218,8 @@ $> openssl speed ecdh</pre>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://h2o.examp1e.net/configure/base_directives.html#ssl-session-resumption-ticket-based">yes</a></td>
             <td class="ok"><a href="https://h2o.examp1e.net/configure/http2_directives.html">yes</a></td>
-            <td class="alert">no</td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://github.com/h2o/h2o/releases/tag/v2.2.0">yes</a></td>
+            <td class="ok"><a href="https://github.com/h2o/h2o/releases/tag/v2.2.0">yes</td>
           </tr>
           <tr>
             <td><a href="https://cbonte.github.io/haproxy-dconv/configuration-1.5.html">HAProxy</a></td>


### PR DESCRIPTION
H2O grew support for TLS1.3 in 2.2.0 by bundling an newer version of PicoTLS.

Linked to release notes since I couldn't find too specific info to tls 1.3 on the website. Will do another PR when upstream documentation gets updated.