### PR TITLE
index.html: Add TLSv1.3 support to nginx

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,7 @@ $> openssl speed ecdh</pre>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx">yes</a></td>
             <td class="ok"><a href="https://www.nginx.com/blog/early-alpha-patch-http2/">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://twitter.com/nginxorg/status/856896480497385473">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
As of version 1.13.0 (mainline) nginx now now supports TLSv1.3.

See: https://twitter.com/nginxorg/status/856896480497385473