### PR TITLE
AWS CloudFront appears to support Session identifiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@ $> openssl speed ecdh</pre>
           </tr>
           <tr>
             <td>AWS CloudFront</td>
-            <td class="alert">no</td>
+            <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="alert">no</td>


### PR DESCRIPTION
[ssllabs](https://www.ssllabs.com/ssltest/analyze.html?d=d28nqx80pet1gg.cloudfront.net&s=54.192.117.9&latest) says `No (IDs empty)`, but testing by hand I see a session ID and can resume connections.

````
$ echo | openssl s_client -connect d28nqx80pet1gg.cloudfront.net:443 -reconnect  2> /dev/null | grep 'New\|Reuse\|Session-ID:'
New, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES128-GCM-SHA256
    Session-ID: 16FF6-SNIPPED-DFA04F42
Reused, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES128-GCM-SHA256
    Session-ID: 16FF6-SNIPPED-DFA04F42
Reused, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES128-GCM-SHA256
    Session-ID: 16FF6-SNIPPED-DFA04F42
Reused, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES128-GCM-SHA256
    Session-ID: 16FF6-SNIPPED-DFA04F42
Reused, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES128-GCM-SHA256
    Session-ID: 16FF6-SNIPPED-DFA04F42
Reused, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES128-GCM-SHA256
    Session-ID: 16FF6-SNIPPED-DFA04F42
````

````
$ gnutls-cli -r d28nqx80pet1gg.cloudfront.net -p 443
Resolving 'd28nqx80pet1gg.cloudfront.net'...
Connecting to '54.230.156.230:443'...
- Certificate type: X.509
 - Got a certificate list of 2 certificates.
 - Certificate[0] info:
  - subject `C=US,ST=Washington,L=Seattle,O=Amazon.com\, Inc.,CN=*.cloudfront.net', issuer `C=US,O=Symantec Corporation,OU=Symantec Trust Network,CN=Symantec Class 3 Secure Server CA - G4', RSA key 2048 bits, signed using RSA-SHA256, activated `2016-10-26 00:00:00 UTC', expires `2017-12-17 23:59:59 UTC', SHA-1 fingerprint `f207b0c2158dd482da6b8e78fe7a635e010ed978'
 - Certificate[1] info:
  - subject `C=US,O=Symantec Corporation,OU=Symantec Trust Network,CN=Symantec Class 3 Secure Server CA - G4', issuer `C=US,O=VeriSign\, Inc.,OU=VeriSign Trust Network,OU=(c) 2006 VeriSign\, Inc. - For authorized use only,CN=VeriSign Class 3 Public Primary Certification Authority - G5', RSA key 2048 bits, signed using RSA-SHA256, activated `2013-10-31 00:00:00 UTC', expires `2023-10-30 23:59:59 UTC', SHA-1 fingerprint `ff67367c5cd4de4ae18bcce1d70fdabd7c866135'
- The hostname in the certificate matches 'd28nqx80pet1gg.cloudfront.net'.
- Peer's certificate issuer is unknown
- Peer's certificate is NOT trusted
- Version: TLS1.2
- Key Exchange: RSA
- Cipher: AES-128-CBC
- MAC: SHA256
- Compression: NULL
- Handshake was completed
- Certificate type: X.509
 - Got a certificate list of 2 certificates.
 - Certificate[0] info:
  - subject `C=US,ST=Washington,L=Seattle,O=Amazon.com\, Inc.,CN=*.cloudfront.net', issuer `C=US,O=Symantec Corporation,OU=Symantec Trust Network,CN=Symantec Class 3 Secure Server CA - G4', RSA key 2048 bits, signed using RSA-SHA256, activated `2016-10-26 00:00:00 UTC', expires `2017-12-17 23:59:59 UTC', SHA-1 fingerprint `f207b0c2158dd482da6b8e78fe7a635e010ed978'
 - Certificate[1] info:
  - subject `C=US,O=Symantec Corporation,OU=Symantec Trust Network,CN=Symantec Class 3 Secure Server CA - G4', issuer `C=US,O=VeriSign\, Inc.,OU=VeriSign Trust Network,OU=(c) 2006 VeriSign\, Inc. - For authorized use only,CN=VeriSign Class 3 Public Primary Certification Authority - G5', RSA key 2048 bits, signed using RSA-SHA256, activated `2013-10-31 00:00:00 UTC', expires `2023-10-30 23:59:59 UTC', SHA-1 fingerprint `ff67367c5cd4de4ae18bcce1d70fdabd7c866135'
- The hostname in the certificate matches 'd28nqx80pet1gg.cloudfront.net'.
- Peer's certificate issuer is unknown
- Peer's certificate is NOT trusted
- Version: TLS1.2
- Key Exchange: RSA
- Cipher: AES-128-CBC
- MAC: SHA256
- Compression: NULL
- Disconnecting


- Connecting again- trying to resume previous session
Resolving 'd28nqx80pet1gg.cloudfront.net'...
Connecting to '54.230.156.31:443'...
- Certificate type: X.509
 - Got a certificate list of 2 certificates.
 - Certificate[0] info:
  - subject `C=US,ST=Washington,L=Seattle,O=Amazon.com\, Inc.,CN=*.cloudfront.net', issuer `C=US,O=Symantec Corporation,OU=Symantec Trust Network,CN=Symantec Class 3 Secure Server CA - G4', RSA key 2048 bits, signed using RSA-SHA256, activated `2016-10-26 00:00:00 UTC', expires `2017-12-17 23:59:59 UTC', SHA-1 fingerprint `f207b0c2158dd482da6b8e78fe7a635e010ed978'
 - Certificate[1] info:
  - subject `C=US,O=Symantec Corporation,OU=Symantec Trust Network,CN=Symantec Class 3 Secure Server CA - G4', issuer `C=US,O=VeriSign\, Inc.,OU=VeriSign Trust Network,OU=(c) 2006 VeriSign\, Inc. - For authorized use only,CN=VeriSign Class 3 Public Primary Certification Authority - G5', RSA key 2048 bits, signed using RSA-SHA256, activated `2013-10-31 00:00:00 UTC', expires `2023-10-30 23:59:59 UTC', SHA-1 fingerprint `ff67367c5cd4de4ae18bcce1d70fdabd7c866135'
- The hostname in the certificate matches 'd28nqx80pet1gg.cloudfront.net'.
- Peer's certificate issuer is unknown
- Peer's certificate is NOT trusted
- Version: TLS1.2
- Key Exchange: RSA
- Cipher: AES-128-CBC
- MAC: SHA256
- Compression: NULL
- Handshake was completed
*** This is a resumed session

````