### PR TITLE
Removed outdated Netlify support for OCSP Stapling

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,7 +567,7 @@ $> openssl speed ecdh</pre>
             <td>Netlify</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="ok">yes</td>
+            <td class="alert">no</td>
             <td class="ok">dynamic</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>


### PR DESCRIPTION
Messages confirming the removal can be found [here](https://gitter.im/netlify/community?at=5a1f1fbf87680e6230af714c).
They hope to add it back in the future.