### PR TITLE
Fix Node.js ALPN/NPN link

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener">yes</a></td>
             <td class="warn"><a href="https://nodejs.org/api/tls.html#tls_event_ocsprequest">optional</a></td>
             <td class="warn"><a href="https://nodejs.org/api/tls.html#tls_tlssocket_setmaxsendfragment_size">optional</a></td>
-            <td class="ok"><a href="https://nodejs.org/api/tls.html#tls_npn_and_sni">yes</a></td>
+            <td class="ok"><a href="https://nodejs.org/api/tls.html#tls_event_secureconnection">yes</a></td>
             <td class="ok"><a href="https://nodejs.org/api/tls.html#tls_perfect_forward_secrecy">yes</a></td>
             <td class="ok"><a href="https://github.com/molnarg/node-http2">yes</a></td>
             <td class="alert">no</td>


### PR DESCRIPTION
Note that the old link seemed to refer to a different section, but that section is basically a glossary. So I changed it to one that actually describes the API.