### PR TITLE
CDN77 with the latest TLS 1.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,7 +440,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://client.cdn77.com/support/knowledgebase/general-faq/ssl-tech-specs">yes</a></td>
             <td class="ok"><a href="https://client.cdn77.com/support/knowledgebase/general-faq/ssl-tech-specs">yes</a></td>
             <td class="ok"><a href="https://www.cdn77.com/http2">yes</a></td>
-            <td class="warn"><a href="https://www.cdn77.com/blog/cdn77-tls-1-3-supported">beta</a></td>
+            <td class="ok"><a href="https://www.cdn77.com/blog/latest-tls-improving-https/">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
Hi Ilya,

We've launched the latest TLS 1.3 a few weeks ago. Working on 0-RTT right now, it will be added by the end of October.

I'd also like to introduce our TLS checker made for a quick server or CDN check of its SSL/TLS protocols setup: https://www.cdn77.com/tls-test It's faster than other testing tools as it only goes for the protocol versions.

Have a great day,
Michal