### PR TITLE
Add TLS 1.3 to Go and Caddy

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://caddyserver.com/docs/tls#summary">yes</a></td>
             <td class="ok"><a href="https://caddyserver.com/docs/tls#summary">yes</a></td>
             <td class="ok"><a href="https://caddyserver.com/docs/tls#summary">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://github.com/mholt/caddy/issues/2080#issuecomment-439564485">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>
@@ -302,7 +302,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config">yes</a></td>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config">yes</a></td>
             <td class="ok"><a href="https://golang.org/doc/go1.6#http2">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://github.com/golang/go/issues/9671#issuecomment-437431164">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
This PR adds support for TLS 1.3 (RFC 8446) to Go and Caddy. TLS 1.3 support was [recently added to Go](https://github.com/golang/go/issues/9671#issuecomment-437431164). Caddy is written in Go and if you compile it with the latest branch of Go and apply [a tiny patch](https://www.hnrk.io/md/caddy.patch.html) to it, Caddy [also supports TLS 1.3](https://github.com/mholt/caddy/issues/2080#issuecomment-439564485). To see an example of a site using Caddy with TLS 1.3, click [here](https://www.ssllabs.com/ssltest/analyze.html?d=hnrk.io&s=37.228.132.233).