### PR TITLE
Note Hitch supports TLS 1.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://github.com/varnish/hitch/blob/master/docs/configuration.md#alpnnpn-support">yes</a></td>
             <td class="ok">yes</td>
             <td class=warn><a href="https://github.com/varnish/hitch/blob/master/CHANGES.rst#hitch-140-beta1-2016-08-26">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://github.com/varnish/hitch/blob/master/CHANGES.rst#hitch-150-2018-12-17">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
Hitch 1.5.0 adds support for TLS 1.3 (see: https://github.com/varnish/hitch/blob/master/CHANGES.rst#hitch-150-2018-12-17)