### PR TITLE
Remove bud from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,18 +173,6 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
             <td class="alert">no</td>
           </tr>
-         <tr>
-            <td><a href="https://github.com/indutny/bud">bud</a></td>
-            <td class="alert">no</td>
-            <td class="ok">yes</td>
-            <td class="ok"><a href="https://github.com/indutny/bud#ocsp-stapling">yes</a></td>
-            <td class="warn">static</td>
-            <td class="ok">yes</td>
-            <td class="ok">yes</td>
-            <td class="alert">no</td>
-            <td class="alert">no</td>
-            <td class="alert">no</td>
-          </tr>
           <tr>
             <td><a href="https://github.com/mholt/caddy">Caddy</a></td>
             <td class="ok"><a href="https://caddyserver.com/docs/tls#summary">yes</a></td>


### PR DESCRIPTION
bud was deprecated and its repository was archived about two months ago: https://github.com/indutny/bud

This software is no longer being developed and should therefore be removed from the list.