### PR TITLE
Support for TLS 1.3 based on RFC8446 is added in F5 BIG-IP 14.1.0.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://support.f5.com/kb/en-us/products/big-ip-aam/manuals/product/aam-concepts-11-6-0/15.html">yes</a></td>
             <td class="ok"><a href="https://support.f5.com/kb/en-us/solutions/public/13000/100/sol13163.html">yes</a></td>
             <td class="ok"><a href="https://support.f5.com/kb/en-us/products/big-ip-aam/manuals/product/aam-concepts-11-6-0/15.html">yes</a></td>
-            <td class="warn"><a href="https://support.f5.com/kb/en-us/products/big-ip_ltm/releasenotes/product/relnote-bigip-14-0-0.html#rn_ltm-tmos_new">beta</a></td>
+            <td class="ok"><a href="https://support.f5.com/kb/en-us/products/big-ip_ltm/releasenotes/product/relnote-bigip-14-1-0.html#rn_ltm-tmos_14101_new">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
This PR adds support for TLS 1.3 (RFC 8446) to F5 BIG-IP. TLS 1.3 support based on RFC 8446 was [added to F5 BIG-IP in version 14.1.0.1 and released on January 23rd, 2019](https://support.f5.com/kb/en-us/products/big-ip_ltm/releasenotes/product/relnote-bigip-14-1-0.html#rn_ltm-tmos_14101_new). 