### PR TITLE
Add TLS 1.3 support to Go and Caddy

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://caddyserver.com/docs/tls#summary">yes</a></td>
             <td class="ok"><a href="https://caddyserver.com/docs/tls#summary">yes</a></td>
             <td class="ok"><a href="https://caddyserver.com/docs/tls#summary">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://caddyserver.com/docs/tls#protocols">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>
@@ -290,7 +290,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config">yes</a></td>
             <td class="ok"><a href="https://golang.org/pkg/crypto/tls/#Config">yes</a></td>
             <td class="ok"><a href="https://golang.org/doc/go1.6#http2">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://golang.org/doc/go1.12#tls_1_3">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
This PR adds support for TLS 1.3 (RFC 8446) to Go and Caddy. It replaces the previous PR #181.