### PR TITLE
Update name of NetScaler, add TLS 1.3 support to Citrix ADC and nghttpx and TLS 1.3 0-RTT support to nghttpx

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,12 +248,12 @@ $> openssl speed ecdh</pre>
           <tr>
             <td><a href="https://www.citrix.com/products/citrix-adc/?posit=glnav">Citrix ADC</a></td>
             <td class="ok"><a href="https://support.citrix.com/article/CTX121925">yes</a></td>
-            <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11-1/ssl/customize-ssl-config/support-for-tls-session-ticket-extension.html">yes</a></td>
+            <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/12/ssl/ssl-profiles/ssl-enabling-the-default-profile.html">yes</a></td>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11-1/ssl/ssl-11-1-ocsp-stapling-solution.html">yes</a></td>
             <td class="alert">no</td>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://support.citrix.com/proddocs/topic/netscaler-traffic-management-10-5-map/ns-ssl-config-ecdhe-ciphers-tsk.html">yes</a></td>
-            <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11/system/http-configurations/configuring-http2.html">yes</a></td>
+            <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/12/system/http-configurations/configuring-http2.html">yes</a></td>
             <td class="ok"><a href="https://www.citrix.com/blogs/2018/09/11/citrix-announces-adc-support-for-tls-1-3/">yes</a></td>
             <td class="alert">no</td>
           </tr>

--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
           </tr>
           <tr>
-            <td><a href="https://www.citrix.com/products/netscaler-application-delivery-controller/overview.html?posit=glnav">NetScaler</a></td>
+            <td><a href="https://www.citrix.com/products/netscaler-application-delivery-controller/overview.html?posit=glnav">Citrix ADC</a></td>
             <td class="ok"><a href="https://support.citrix.com/article/CTX121925">yes</a></td>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11-1/ssl/customize-ssl-config/support-for-tls-session-ticket-extension.html">yes</a></td>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11-1/ssl/ssl-11-1-ocsp-stapling-solution.html">yes</a></td>
@@ -254,7 +254,7 @@ $> openssl speed ecdh</pre>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://support.citrix.com/proddocs/topic/netscaler-traffic-management-10-5-map/ns-ssl-config-ecdhe-ciphers-tsk.html">yes</a></td>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11/system/http-configurations/configuring-http2.html">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://www.citrix.com/blogs/2018/09/11/citrix-announces-adc-support-for-tls-1-3/">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@ $> openssl speed ecdh</pre>
             <td><a href="https://www.citrix.com/products/citrix-adc/?posit=glnav">Citrix ADC</a></td>
             <td class="ok"><a href="https://support.citrix.com/article/CTX121925">yes</a></td>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/12/ssl/ssl-profiles/ssl-enabling-the-default-profile.html">yes</a></td>
-            <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11-1/ssl/ssl-11-1-ocsp-stapling-solution.html">yes</a></td>
+            <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/12/ssl/ssl-11-1-ocsp-stapling-solution.html">yes</a></td>
             <td class="alert">no</td>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/12/ssl/ciphers-available-on-the-citrix-ADC-appliances/diffie-hellman-key-generation-and-achieving-pfs-with-dhe.html">yes</a></td>

--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
           </tr>
           <tr>
-            <td><a href="https://www.citrix.com/products/netscaler-application-delivery-controller/overview.html?posit=glnav">Citrix ADC</a></td>
+            <td><a href="https://www.citrix.com/products/citrix-adc/?posit=glnav">Citrix ADC</a></td>
             <td class="ok"><a href="https://support.citrix.com/article/CTX121925">yes</a></td>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11-1/ssl/customize-ssl-config/support-for-tls-session-ticket-extension.html">yes</a></td>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11-1/ssl/ssl-11-1-ocsp-stapling-solution.html">yes</a></td>

--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/11-1/ssl/ssl-11-1-ocsp-stapling-solution.html">yes</a></td>
             <td class="alert">no</td>
             <td class="ok">yes</td>
-            <td class="ok"><a href="https://support.citrix.com/proddocs/topic/netscaler-traffic-management-10-5-map/ns-ssl-config-ecdhe-ciphers-tsk.html">yes</a></td>
+            <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/12/ssl/ciphers-available-on-the-citrix-ADC-appliances/diffie-hellman-key-generation-and-achieving-pfs-with-dhe.html">yes</a></td>
             <td class="ok"><a href="https://docs.citrix.com/en-us/netscaler/12/system/http-configurations/configuring-http2.html">yes</a></td>
             <td class="ok"><a href="https://www.citrix.com/blogs/2018/09/11/citrix-announces-adc-support-for-tls-1-3/">yes</a></td>
             <td class="alert">no</td>

--- a/index.html
+++ b/index.html
@@ -302,8 +302,8 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--npn-list">yes</a></td>
             <td class="ok"><a href="https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--ciphers">yes</a></td>
             <td class="ok"><a href="https://nghttp2.org/documentation/nghttpx.1.html#http-2-and-spdy">yes</a></td>
-            <td class="alert">no</td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://nghttp2.org/blog/2018/10/04/nghttp2-v1-34-0/">yes</a></td>
+            <td class="ok"><a href="https://nghttp2.org/blog/2018/10/04/nghttp2-v1-34-0/">yes</a></td>
           </tr>
           <tr>
             <td><a href="https://www.pulsesecure.net/vtm">Pulse Secure vTM</a></td>


### PR DESCRIPTION
Support for TLS 1.3 and TLS 1.3 0-RTT was added to nghttpx in v1.34.0: https://nghttp2.org/blog/2018/10/04/nghttp2-v1-34-0/

NetScaler was renamed to Citrix ADC and had support for TLS 1.3 added in September last year: https://www.citrix.com/blogs/2018/09/11/citrix-announces-adc-support-for-tls-1-3/