### PR TITLE
Node now supports TLS 1.3!

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,8 +277,8 @@ $> openssl speed ecdh</pre>
             <td class="warn"><a href="https://nodejs.org/api/tls.html#tls_tlssocket_setmaxsendfragment_size">optional</a></td>
             <td class="ok"><a href="https://nodejs.org/api/tls.html#tls_event_secureconnection">yes</a></td>
             <td class="ok"><a href="https://nodejs.org/api/tls.html#tls_perfect_forward_secrecy">yes</a></td>
-            <td class="ok"><a href="https://github.com/molnarg/node-http2">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://nodejs.org/dist/latest-v12.x/docs/api/http2.html">yes</a></td>
+            <td class="ok"><a href="https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#2019-04-23-version-1200-current-bethgriggs">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
I also updated the HTTP/2 link to point to the nodejs.org docs about the built-in HTTP/2 server.