### PR TITLE
Akamai TLS 1.3 support is no longer beta.

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,12 +363,12 @@ $> openssl speed ecdh</pre>
             <td>Akamai</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="ok"><a href="https://community.akamai.com/community/web-performance/blog/2017/10/27/certificate-provisioning-system-recommendations-and-best-practices">yes</a></td>
+            <td class="ok"><a href="https://community.akamai.com/customers/s/article/WebPerformanceCertificateProvisioningSystemCPSRecommendationsandBestPractices20180719231737">yes</a></td>
             <td class="warn">configurable (static)</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://http2.akamai.com/">yes</a></td>
-            <td class="warn"><a href="https://community.akamai.com/community/web-performance/blog/2017/10/25/get-ready-for-tls-13">beta</a></td>
+            <td class="ok"><a href="https://community.akamai.com/customers/s/article/Get-ready-for-TLS-1-3">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
also updated documentation links.