### PR TITLE
New company name, OCSP and TLS 1.3 support

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,16 +516,16 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
           </tr>
           <tr>
-            <td>Instart Logic</td>
+            <td>Instart</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
-            <td class="alert">no</td>
+            <td class="ok">yes</td>
             <td class="warn">configurable (static)</td>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://www.instartlogic.com/blog/upgrading-http2">yes</a></td>
-            <td class="alert">no</td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://www.instart.com/blog/may-2019-new-instart-features">yes</a></td>
+            <td class="ok"><a href="https://www.instart.com/blog/may-2019-new-instart-features">yes</a></td>
           </tr>
           <tr>
             <td>KeyCDN</td>


### PR DESCRIPTION
Updated Instart company name and latest information on what TLS features we support.