### PR TITLE
StackPath now supports TLS 1.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -560,7 +560,7 @@ $> openssl speed ecdh</pre>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://www.maxcdn.com/blog/http2-support/">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok">yes</td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
StackPath now supports TLS 1.3:

```
$ openssl s_client -tls1_3 www.stackpath.com:443 | grep 'TLSv1.3'
depth=2 C = US, ST = New Jersey, L = Jersey City, O = The USERTRUST Network, CN = USERTrust RSA Certification Authority
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=1 C = GB, ST = Greater Manchester, L = Salford, O = Sectigo Limited, CN = Sectigo RSA Domain Validation Secure Server CA
verify return:1
depth=0 OU = Domain Control Validated, CN = www.stackpath.com
verify return:1
New, TLSv1.3, Cipher is TLS_AES_128_GCM_SHA256
```