### PR TITLE
H2 support in Hitch has been stable for years.

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@ $> openssl speed ecdh</pre>
             <td class="alert">no</td>
             <td class="ok"><a href="https://github.com/varnish/hitch/blob/master/docs/configuration.md#alpnnpn-support">yes</a></td>
             <td class="ok">yes</td>
-            <td class=warn><a href="https://github.com/varnish/hitch/blob/master/CHANGES.rst#hitch-140-beta1-2016-08-26">yes</a></td>
+            <td class=ok><a href="https://github.com/varnish/hitch/blob/master/docs/configuration.md#alpnnpn-support">yes</a></td>
             <td class="ok"><a href="https://github.com/varnish/hitch/blob/master/CHANGES.rst#hitch-150-2018-12-17">yes</a></td>
             <td class="alert">no</td>
           </tr>


### PR DESCRIPTION
However, there isn't a dedicated documentation page about H2 support. We use the `alpn-protos` directive to configure H2 as shown in https://github.com/varnish/hitch/blob/master/docs/configuration.md#alpnnpn-support

My suggestion is to link to this page. You already referred to it in the ALPN section. If you don't like this, I can change it into `<td class="ok">yes</td>`