### PR TITLE
Fastly supports TLS 1.3 and 0-RTT

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,8 +476,8 @@ $> openssl speed ecdh</pre>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://www.fastly.com/blog/http2-now-general-availability">yes</a></td>
-            <td class="alert">no</td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://docs.fastly.com/en/guides/enabling-tls-1-3-through-fastly">yes</a></td>
+            <td class="warn"><a href="https://docs.fastly.com/en/guides/enabling-tls-1-3-through-fastly#limitations-and-key-behaviors">client->Fastly only</a></td>
           </tr>
           <tr>
             <td>Google App Engine</td>


### PR DESCRIPTION
Press release and video: https://www.fastly.com/blog/tls13-available

0-RTT may class as "Yes" rather than "warn". Fastly say:

> Fastly currently only supports 0-RTT between Fastly and requesting clients. We do not support 0-RTT between Fastly and your origin servers.
By default, Fastly only answers idempotent requests (GET and HEAD requests without query parameters) over 0-RTT. This helps protect customer applications from replay attacks.
Requests issued with 0-RTT will include an Early-Data:1 header per RFC 8470. This attribute can be queried and logged via VCL using req.http.early-data.

Closes #202 