### PR TITLE
Limelight supports TLSv1.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,7 +548,7 @@ $> openssl speed ecdh</pre>
             <td class="ok">yes</td>
             <td class="ok">yes</td>
             <td class="ok"><a href="https://www.limelight.com/orchestrate-platform/">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok">yes</td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
An email went out to customers in 2019 that TLSv1.3 to was supported and that it was being enabled for any customers that didn't requests specific protocols

Unfortunately I could not find public product specs or blog posting that denote Limelight's capabilities. Running an SSL labs tests against www.limelight.com: 

https://www.ssllabs.com/ssltest/analyze.html?d=llnw%2ddd.lldns.net&s=68.142.68.1

