### PR TITLE
Add TLS 1.3 support for IIS

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://technet.microsoft.com/en-us/library/hh831771.aspx">yes</a></td>
             <td class="ok"><a href="https://blogs.technet.com/b/erezs_iis_blog/archive/2013/08/22/perfect-secrecy-in-an-imperfect-world.aspx">yes</a></td>
             <td class="ok"><a href="https://blogs.iis.net/nazim/http-2-for-iis-in-windows-10-technical-preview">yes</a></td>
-            <td class="alert">no</td>
+            <td class="ok"><a href="https://docs.microsoft.com/en-us/windows-server/get-started/whats-new-in-windows-server-2022#transport-https-and-tls-13-enabled-by-default-on-windows-server-2022">yes</td>
             <td class="alert">no</td>
           </tr>
           <tr>

--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@ $> openssl speed ecdh</pre>
             <td class="ok"><a href="https://technet.microsoft.com/en-us/library/hh831771.aspx">yes</a></td>
             <td class="ok"><a href="https://blogs.technet.com/b/erezs_iis_blog/archive/2013/08/22/perfect-secrecy-in-an-imperfect-world.aspx">yes</a></td>
             <td class="ok"><a href="https://blogs.iis.net/nazim/http-2-for-iis-in-windows-10-technical-preview">yes</a></td>
-            <td class="ok"><a href="https://docs.microsoft.com/en-us/windows-server/get-started/whats-new-in-windows-server-2022#transport-https-and-tls-13-enabled-by-default-on-windows-server-2022">yes</td>
+            <td class="ok"><a href="https://docs.microsoft.com/en-us/windows-server/get-started/whats-new-in-windows-server-2022#transport-https-and-tls-13-enabled-by-default-on-windows-server-2022">yes</a></td>
             <td class="alert">no</td>
           </tr>
           <tr>


### PR DESCRIPTION
With the release of Windows Server 2022, IIS now finally supports TLS 1.3.